### PR TITLE
Add LAS 1.4 sample with extra dims for QTM testing

### DIFF
--- a/liblas/SerpentMound_LAS14_ExtraDims.laz
+++ b/liblas/SerpentMound_LAS14_ExtraDims.laz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:779992129d67554157361ed3609afed7e52d16e930b65ed53ea31a4ac42f3e6d
+size 1509206


### PR DESCRIPTION
Created from https://github.com/PDAL/PDAL/commit/81039f582a3331f38c39413431ff94928b907883.

```
pdal translate Serpent\ Mound\ Model\ LAS\ Data.laz SerpentMound_LAS14_ExtraDims.laz covariancefeatures sample -v 5 --filters.covariancefeatures.knn=45 --filters.sample.radius=5 --writers.las.forward="all" --writers.las.extra_dims="all" --writers.las.minor_version=4
```